### PR TITLE
Widget picker: scrollable 3-column previews with button colors

### DIFF
--- a/Menus/Button_Settings_Menu.lua
+++ b/Menus/Button_Settings_Menu.lua
@@ -596,13 +596,26 @@ end
 function ButtonSettingsMenu:showWidgetSelector(button)
     local widget_list = C.WidgetsManager:getWidgetList()
 
-    -- Store widgets and button for the selection menu
     self.widget_selection = {
         widget_list = widget_list,
         button = button,
-        selected_index = 1,
-        is_open = true
+        selected_index = #widget_list > 0 and 1 or 0,
+        is_open = true,
+        preview_cache = {},
+        preview_style_custom = button.custom_color and CONFIG_MANAGER:deepCopy(button.custom_color) or nil,
+        preview_style_user = button.user_colors and CONFIG_MANAGER:deepCopy(button.user_colors) or nil,
+        preview_style_border = button.border_offset
+            and { saturation = button.border_offset.saturation, value = button.border_offset.value }
+            or nil,
+        preview_button_shell = self._widget_preview_shell
     }
+
+    if not self._widget_preview_shell then
+        local shell = C.ButtonDefinition.createButton("65535", "")
+        shell.saveChanges = function() end
+        self._widget_preview_shell = shell
+        self.widget_selection.preview_button_shell = shell
+    end
 
     -- Set a flag to open the widget selector popup in the next frame
     self.show_widget_selector = true
@@ -615,21 +628,22 @@ function ButtonSettingsMenu:renderWidgetSelector(ctx)
 
     local mouseX, mouseY = reaper.ImGui_GetMousePos(ctx)
     reaper.ImGui_SetNextWindowPos(ctx, mouseX, mouseY, reaper.ImGui_Cond_FirstUseEver())
-    reaper.ImGui_SetNextWindowSize(ctx, 400, 300, reaper.ImGui_Cond_FirstUseEver())
+    reaper.ImGui_SetNextWindowSize(ctx, 580, 420, reaper.ImGui_Cond_FirstUseEver())
 
-    local window_flags =
-        reaper.ImGui_WindowFlags_NoCollapse() | reaper.ImGui_WindowFlags_NoDocking() |
-        reaper.ImGui_WindowFlags_NoResize()
+    local window_flags = reaper.ImGui_WindowFlags_NoCollapse() | reaper.ImGui_WindowFlags_NoDocking()
     local colorCount, styleCount = C.GlobalStyle.apply(ctx)
-    
-    -- Use instance_id for unique window identification
+
     local window_title = "Select Widget##" .. self.widget_selection.button.instance_id
     local visible, open = reaper.ImGui_Begin(ctx, window_title, true, window_flags)
     self.widget_selection.is_open = open
 
     if visible then
+        local sel = self.widget_selection
+
         local function applySelectedWidget()
-            local sel = self.widget_selection
+            if sel.selected_index < 1 or sel.selected_index > #sel.widget_list then
+                return
+            end
             local w = sel.widget_list[sel.selected_index]
             if C.WidgetsManager:assignWidgetToButton(sel.button, w.name) then
                 sel.button:clearCache()
@@ -640,32 +654,108 @@ function ButtonSettingsMenu:renderWidgetSelector(ctx)
             end
         end
 
-        reaper.ImGui_TextWrapped(ctx, "Select a widget to assign to this button:")
+        reaper.ImGui_TextWrapped(
+            ctx,
+            "Preview uses this button's colors. Double-click a tile or select one and click OK to assign."
+        )
         reaper.ImGui_Separator(ctx)
-        reaper.ImGui_BeginChild(ctx, "WidgetList", 0, -30)
 
-        for i, widget in ipairs(self.widget_selection.widget_list) do
-            if reaper.ImGui_Selectable(ctx, widget.display_name, i == self.widget_selection.selected_index) then
-                self.widget_selection.selected_index = i
+        local columns = 3
+        local avail_w = reaper.ImGui_GetContentRegionAvail(ctx)
+        local sp_x = select(1, reaper.ImGui_GetStyleVar(ctx, reaper.ImGui_StyleVar_ItemSpacing()))
+        local cell_w = math.max(80, (avail_w - sp_x * (columns - 1)) / columns)
+        local cell_h = CONFIG.SIZES.HEIGHT + 14
+        local pad = 4
+
+        local shell = sel.preview_button_shell or self._widget_preview_shell
+        shell.custom_color = sel.preview_style_custom
+        shell.user_colors = sel.preview_style_user
+        shell.border_offset = sel.preview_style_border
+        if shell.cache.colors then
+            shell.cache.colors = nil
+        end
+
+        local scroll_h = math.max(120, reaper.ImGui_GetContentRegionAvail(ctx) - 36)
+        reaper.ImGui_BeginChild(ctx, "WidgetPreviewGrid", 0, scroll_h, reaper.ImGui_ChildFlags_Border and reaper.ImGui_ChildFlags_Border() or 0)
+
+        for i, widget_entry in ipairs(sel.widget_list) do
+            if i > 1 and (i - 1) % columns ~= 0 then
+                reaper.ImGui_SameLine(ctx, 0, sp_x)
             end
 
+            reaper.ImGui_PushID(ctx, "wsel_" .. widget_entry.name)
+
+            local is_selected = i == sel.selected_index
+            if is_selected then
+                reaper.ImGui_PushStyleColor(ctx, reaper.ImGui_Col_Border(), 0xFF6BA6FFFF)
+            end
+
+            local child_flags = reaper.ImGui_ChildFlags_Border and reaper.ImGui_ChildFlags_Border() or 0
+            reaper.ImGui_BeginChild(ctx, "tile", cell_w, cell_h, child_flags)
+
+            if not sel.preview_cache[widget_entry.name] then
+                sel.preview_cache[widget_entry.name] = C.WidgetsManager:cloneWidgetInstance(widget_entry.name)
+            end
+            shell.widget = sel.preview_cache[widget_entry.name]
+            shell:clearLayoutCache()
+            C.LayoutManager:calculateWidgetButtonWidth(ctx, shell)
+            local layout = shell.cache.layout
+            local max_inner = cell_w - pad * 2
+            local draw_w = math.min(layout.width, max_inner)
+
+            local coords = COORDINATES.new(ctx)
+            local draw_list = reaper.ImGui_GetWindowDrawList(ctx)
+            local state_key = C.Interactions:determineStateKey(shell)
+            local bg_color, border_color = COLOR_UTILS.getButtonColors(shell, state_key, "NORMAL")
+
+            local draw_layout = {
+                width = draw_w,
+                height = CONFIG.SIZES.HEIGHT,
+                extra_padding = layout.extra_padding or 0
+            }
+
+            C.ButtonRenderer:renderBackground(draw_list, shell, pad, pad, draw_w, bg_color, border_color, coords, false)
+            C.WidgetRenderer:renderWidgetPreview(ctx, shell, pad, pad, coords, draw_list, draw_layout)
+
+            reaper.ImGui_SetCursorPos(ctx, pad, pad)
+            reaper.ImGui_InvisibleButton(ctx, "##pick", draw_w, CONFIG.SIZES.HEIGHT)
+
+            if reaper.ImGui_IsItemClicked(ctx, 0) then
+                sel.selected_index = i
+            end
             if reaper.ImGui_IsItemHovered(ctx) and reaper.ImGui_IsMouseDoubleClicked(ctx, 0) then
-                self.widget_selection.selected_index = i
+                sel.selected_index = i
                 applySelectedWidget()
+            end
+
+            reaper.ImGui_SetCursorPos(ctx, pad, pad + CONFIG.SIZES.HEIGHT + 2)
+            reaper.ImGui_PushTextWrapPos(ctx, reaper.ImGui_GetCursorPosX(ctx) + max_inner)
+            reaper.ImGui_TextWrapped(ctx, widget_entry.display_name)
+            reaper.ImGui_PopTextWrapPos(ctx)
+
+            reaper.ImGui_EndChild(ctx)
+
+            if is_selected then
+                reaper.ImGui_PopStyleColor(ctx)
             end
 
             if reaper.ImGui_IsItemHovered(ctx) then
                 reaper.ImGui_BeginTooltip(ctx)
-                reaper.ImGui_Text(ctx, widget.display_name)
-                reaper.ImGui_Text(ctx, "Type: " .. widget.type)
-                if widget.description and widget.description ~= "" then
-                    reaper.ImGui_Text(ctx, "Description: " .. widget.description)
+                reaper.ImGui_Text(ctx, widget_entry.display_name)
+                reaper.ImGui_Text(ctx, "Type: " .. widget_entry.type)
+                if widget_entry.description and widget_entry.description ~= "" then
+                    reaper.ImGui_TextWrapped(ctx, widget_entry.description)
                 end
                 reaper.ImGui_EndTooltip(ctx)
             end
+
+            reaper.ImGui_PopID(ctx)
         end
 
         reaper.ImGui_EndChild(ctx)
+
+        shell.widget = nil
+
         reaper.ImGui_Separator(ctx)
 
         local btn_width = (reaper.ImGui_GetWindowWidth(ctx) - 20) / 2
@@ -675,7 +765,7 @@ function ButtonSettingsMenu:renderWidgetSelector(ctx)
 
         reaper.ImGui_SameLine(ctx)
         if reaper.ImGui_Button(ctx, "Cancel", btn_width, 0) then
-            self.widget_selection.is_open = false
+            sel.is_open = false
         end
     end
 

--- a/Menus/Button_Settings_Menu.lua
+++ b/Menus/Button_Settings_Menu.lua
@@ -628,14 +628,28 @@ function ButtonSettingsMenu:renderWidgetSelector(ctx)
 
     local mouseX, mouseY = reaper.ImGui_GetMousePos(ctx)
     reaper.ImGui_SetNextWindowPos(ctx, mouseX, mouseY, reaper.ImGui_Cond_FirstUseEver())
-    reaper.ImGui_SetNextWindowSize(ctx, 580, 420, reaper.ImGui_Cond_FirstUseEver())
+    reaper.ImGui_SetNextWindowSize(ctx, 760, 520, reaper.ImGui_Cond_FirstUseEver())
 
     local window_flags = reaper.ImGui_WindowFlags_NoCollapse() | reaper.ImGui_WindowFlags_NoDocking()
+    if reaper.ImGui_WindowFlags_NoScrollbar then
+        window_flags = window_flags | reaper.ImGui_WindowFlags_NoScrollbar()
+    end
+    if reaper.ImGui_WindowFlags_NoScrollWithMouse then
+        window_flags = window_flags | reaper.ImGui_WindowFlags_NoScrollWithMouse()
+    end
     local colorCount, styleCount = C.GlobalStyle.apply(ctx)
 
     local window_title = "Select Widget##" .. self.widget_selection.button.instance_id
     local visible, open = reaper.ImGui_Begin(ctx, window_title, true, window_flags)
     self.widget_selection.is_open = open
+    local esc_pressed = reaper.ImGui_IsKeyPressed(ctx, reaper.ImGui_Key_Escape())
+
+    if not open or esc_pressed then
+        self.widget_selection.is_open = false
+        reaper.ImGui_End(ctx)
+        C.GlobalStyle.reset(ctx, colorCount, styleCount)
+        return false
+    end
 
     if visible then
         local sel = self.widget_selection
@@ -660,12 +674,18 @@ function ButtonSettingsMenu:renderWidgetSelector(ctx)
         )
         reaper.ImGui_Separator(ctx)
 
-        local columns = 3
-        local avail_w = reaper.ImGui_GetContentRegionAvail(ctx)
+        local avail_w, avail_h = reaper.ImGui_GetContentRegionAvail(ctx)
+        avail_w = math.max(0, avail_w or 0)
+        avail_h = math.max(0, avail_h or 0)
+        local grid_inner_pad = 16
+        local usable_grid_w = math.max(0, avail_w - (grid_inner_pad * 2))
         local sp_x = select(1, reaper.ImGui_GetStyleVar(ctx, reaper.ImGui_StyleVar_ItemSpacing()))
-        local cell_w = math.max(80, (avail_w - sp_x * (columns - 1)) / columns)
-        local cell_h = CONFIG.SIZES.HEIGHT + 14
-        local pad = 4
+        local min_cell_w = 120
+        local columns = math.max(1, math.floor((usable_grid_w + sp_x) / (min_cell_w + sp_x)))
+        local cell_w = math.max(min_cell_w, math.floor((usable_grid_w - sp_x * (columns - 1)) / columns))
+        local cell_h = CONFIG.SIZES.HEIGHT + 42
+        local pad = 8
+        local tile_rounding = math.max(6, math.floor((CONFIG.SIZES.ROUNDING or 6) * 0.75))
 
         local shell = sel.preview_button_shell or self._widget_preview_shell
         shell.custom_color = sel.preview_style_custom
@@ -675,95 +695,134 @@ function ButtonSettingsMenu:renderWidgetSelector(ctx)
             shell.cache.colors = nil
         end
 
-        local scroll_h = math.max(120, reaper.ImGui_GetContentRegionAvail(ctx) - 36)
-        reaper.ImGui_BeginChild(ctx, "WidgetPreviewGrid", 0, scroll_h, reaper.ImGui_ChildFlags_Border and reaper.ImGui_ChildFlags_Border() or 0)
-
-        for i, widget_entry in ipairs(sel.widget_list) do
-            if i > 1 and (i - 1) % columns ~= 0 then
-                reaper.ImGui_SameLine(ctx, 0, sp_x)
-            end
-
-            reaper.ImGui_PushID(ctx, "wsel_" .. widget_entry.name)
-
-            local is_selected = i == sel.selected_index
-            if is_selected then
-                reaper.ImGui_PushStyleColor(ctx, reaper.ImGui_Col_Border(), 0xFF6BA6FFFF)
-            end
-
-            local child_flags = reaper.ImGui_ChildFlags_Border and reaper.ImGui_ChildFlags_Border() or 0
-            reaper.ImGui_BeginChild(ctx, "tile", cell_w, cell_h, child_flags)
-
-            if not sel.preview_cache[widget_entry.name] then
-                sel.preview_cache[widget_entry.name] = C.WidgetsManager:cloneWidgetInstance(widget_entry.name)
-            end
-            shell.widget = sel.preview_cache[widget_entry.name]
-            shell:clearLayoutCache()
-            C.LayoutManager:calculateWidgetButtonWidth(ctx, shell)
-            local layout = shell.cache.layout
-            local max_inner = cell_w - pad * 2
-            local draw_w = math.min(layout.width, max_inner)
-
-            local coords = COORDINATES.new(ctx)
-            local draw_list = reaper.ImGui_GetWindowDrawList(ctx)
-            local state_key = C.Interactions:determineStateKey(shell)
-            local bg_color, border_color = COLOR_UTILS.getButtonColors(shell, state_key, "NORMAL")
-
-            local draw_layout = {
-                width = draw_w,
-                height = CONFIG.SIZES.HEIGHT,
-                extra_padding = layout.extra_padding or 0
-            }
-
-            C.ButtonRenderer:renderBackground(draw_list, shell, pad, pad, draw_w, bg_color, border_color, coords, false)
-            C.WidgetRenderer:renderWidgetPreview(ctx, shell, pad, pad, coords, draw_list, draw_layout)
-
-            reaper.ImGui_SetCursorPos(ctx, pad, pad)
-            reaper.ImGui_InvisibleButton(ctx, "##pick", draw_w, CONFIG.SIZES.HEIGHT)
-
-            if reaper.ImGui_IsItemClicked(ctx, 0) then
-                sel.selected_index = i
-            end
-            if reaper.ImGui_IsItemHovered(ctx) and reaper.ImGui_IsMouseDoubleClicked(ctx, 0) then
-                sel.selected_index = i
-                applySelectedWidget()
-            end
-
-            reaper.ImGui_SetCursorPos(ctx, pad, pad + CONFIG.SIZES.HEIGHT + 2)
-            reaper.ImGui_PushTextWrapPos(ctx, reaper.ImGui_GetCursorPosX(ctx) + max_inner)
-            reaper.ImGui_TextWrapped(ctx, widget_entry.display_name)
-            reaper.ImGui_PopTextWrapPos(ctx)
-
-            reaper.ImGui_EndChild(ctx)
-
-            if is_selected then
-                reaper.ImGui_PopStyleColor(ctx)
-            end
-
-            if reaper.ImGui_IsItemHovered(ctx) then
-                reaper.ImGui_BeginTooltip(ctx)
-                reaper.ImGui_Text(ctx, widget_entry.display_name)
-                reaper.ImGui_Text(ctx, "Type: " .. widget_entry.type)
-                if widget_entry.description and widget_entry.description ~= "" then
-                    reaper.ImGui_TextWrapped(ctx, widget_entry.description)
+        -- Reserve/pin footer space (help + action buttons) so only the list region scrolls.
+        local footer_reserved_h = 124
+        local list_start_y = reaper.ImGui_GetCursorPosY(ctx)
+        local scroll_h = math.max(120, avail_h - footer_reserved_h)
+        local grid_child_flags = reaper.ImGui_ChildFlags_Border and reaper.ImGui_ChildFlags_Border() or 0
+        local hovered_widget = nil
+        local selected_widget = (sel.selected_index and sel.widget_list[sel.selected_index]) or nil
+        if reaper.ImGui_BeginChild(ctx, "WidgetPreviewGrid", 0, scroll_h, grid_child_flags) then
+            reaper.ImGui_SetCursorPos(ctx, grid_inner_pad, grid_inner_pad)
+            for i, widget_entry in ipairs(sel.widget_list) do
+                local is_row_start = ((i - 1) % columns) == 0
+                if is_row_start then
+                    reaper.ImGui_SetCursorPosX(ctx, grid_inner_pad)
+                else
+                    reaper.ImGui_SameLine(ctx, 0, sp_x)
                 end
-                reaper.ImGui_EndTooltip(ctx)
+
+                local tile_x = reaper.ImGui_GetCursorPosX(ctx)
+                local tile_y = reaper.ImGui_GetCursorPosY(ctx)
+                local tile_screen_x, tile_screen_y = reaper.ImGui_GetCursorScreenPos(ctx)
+
+                reaper.ImGui_InvisibleButton(ctx, "##tile_pick_" .. widget_entry.name, cell_w, cell_h)
+                local tile_hovered = reaper.ImGui_IsItemHovered(ctx)
+                local tile_clicked = reaper.ImGui_IsItemClicked(ctx, 0)
+                local tile_double_clicked = tile_hovered and reaper.ImGui_IsMouseDoubleClicked(ctx, 0)
+                local is_selected = i == sel.selected_index
+
+                if tile_clicked then
+                    sel.selected_index = i
+                    is_selected = true
+                    selected_widget = widget_entry
+                end
+                if tile_double_clicked then
+                    sel.selected_index = i
+                    selected_widget = widget_entry
+                    applySelectedWidget()
+                end
+                if tile_hovered then
+                    hovered_widget = widget_entry
+                end
+
+                if not sel.preview_cache[widget_entry.name] then
+                    sel.preview_cache[widget_entry.name] = C.WidgetsManager:cloneWidgetInstance(widget_entry.name)
+                end
+                shell.widget = sel.preview_cache[widget_entry.name]
+                shell:clearLayoutCache()
+                C.LayoutManager:calculateWidgetButtonWidth(ctx, shell)
+                local layout = shell.cache.layout
+                local max_inner = cell_w - pad * 2
+                local draw_w = max_inner
+
+                local draw_list = reaper.ImGui_GetWindowDrawList(ctx)
+                local base_tile_bg = tile_hovered and 0x383838FF or 0x2D2D2DFF
+                local tile_border = is_selected and 0xE8E5DCFF or (tile_hovered and 0x7D7D7DFF or 0x4F4F4FFF)
+                reaper.ImGui_DrawList_AddRectFilled(
+                    draw_list,
+                    tile_screen_x,
+                    tile_screen_y,
+                    tile_screen_x + cell_w,
+                    tile_screen_y + cell_h,
+                    base_tile_bg,
+                    tile_rounding
+                )
+                reaper.ImGui_DrawList_AddRect(
+                    draw_list,
+                    tile_screen_x,
+                    tile_screen_y,
+                    tile_screen_x + cell_w,
+                    tile_screen_y + cell_h,
+                    tile_border,
+                    tile_rounding,
+                    0,
+                    is_selected and 2 or 1
+                )
+
+                local coords = COORDINATES.new(ctx)
+                local state_key = C.Interactions:determineStateKey(shell)
+                local bg_color, border_color = COLOR_UTILS.getButtonColors(shell, state_key, "NORMAL")
+                local draw_layout = {
+                    width = draw_w,
+                    height = CONFIG.SIZES.HEIGHT,
+                    extra_padding = layout.extra_padding or 0
+                }
+                local preview_x = tile_x + pad
+                local preview_y = tile_y + pad
+                C.ButtonRenderer:renderBackground(draw_list, shell, preview_x, preview_y, draw_w, bg_color, border_color, coords, false)
+                C.WidgetRenderer:renderWidgetPreview(ctx, shell, preview_x, preview_y, coords, draw_list, draw_layout)
+
+                local label_x, label_y = coords:relativeToDrawList(tile_x + pad, tile_y + pad + CONFIG.SIZES.HEIGHT + 6)
+                reaper.ImGui_DrawList_AddText(draw_list, label_x, label_y, 0xD0D0D0FF, widget_entry.display_name)
             end
-
-            reaper.ImGui_PopID(ctx)
+            reaper.ImGui_EndChild(ctx)
         end
-
-        reaper.ImGui_EndChild(ctx)
 
         shell.widget = nil
 
+        -- Anchor footer start to a deterministic Y, independent of content flow.
+        local footer_start_y = list_start_y + scroll_h
+        reaper.ImGui_SetCursorPosY(ctx, footer_start_y)
+
         reaper.ImGui_Separator(ctx)
+        local info = hovered_widget or selected_widget
+        if info then
+            reaper.ImGui_Text(ctx, "Name: " .. (info.display_name or info.name or ""))
+            reaper.ImGui_SameLine(ctx)
+            reaper.ImGui_TextDisabled(ctx, "Type: " .. (info.type or ""))
+            if info.description and info.description ~= "" then
+                reaper.ImGui_TextWrapped(ctx, info.description)
+            else
+                reaper.ImGui_TextDisabled(ctx, "No help text available for this widget.")
+            end
+        else
+            reaper.ImGui_TextDisabled(ctx, "Select a widget to see help information.")
+        end
+
+        -- Pin action buttons to the bottom edge of the reserved footer region.
+        local sp_y = select(2, reaper.ImGui_GetStyleVar(ctx, reaper.ImGui_StyleVar_ItemSpacing()))
+        local fp_y = select(2, reaper.ImGui_GetStyleVar(ctx, reaper.ImGui_StyleVar_FramePadding()))
+        local button_h = reaper.ImGui_GetTextLineHeight(ctx) + (fp_y * 2)
+        local buttons_y = footer_start_y + footer_reserved_h - button_h
+        reaper.ImGui_SetCursorPosY(ctx, buttons_y)
 
         local btn_width = (reaper.ImGui_GetWindowWidth(ctx) - 20) / 2
         if reaper.ImGui_Button(ctx, "OK", btn_width, 0) then
             applySelectedWidget()
         end
 
-        reaper.ImGui_SameLine(ctx)
+        reaper.ImGui_SameLine(ctx, 0, sp_x)
         if reaper.ImGui_Button(ctx, "Cancel", btn_width, 0) then
             sel.is_open = false
         end

--- a/Renderers/_Widgets.lua
+++ b/Renderers/_Widgets.lua
@@ -78,7 +78,7 @@ local function renderDisplayWidget(ctx, widget, rel_x, rel_y, render_width, coor
     end
 end
 
-local function renderSliderWidget(ctx, widget, rel_x, rel_y, render_width, coords, draw_list, text_color)
+local function renderSliderWidget(ctx, widget, rel_x, rel_y, render_width, coords, draw_list, text_color, preview_mode)
     local height = CONFIG.SIZES.HEIGHT
 
     -- Check if widget is disabled
@@ -153,53 +153,55 @@ local function renderSliderWidget(ctx, widget, rel_x, rel_y, render_width, coord
         reaper.ImGui_DrawList_AddText(draw_list, label_x, label_y, text_color_half, widget.label)
     end
 
-    local is_active = reaper.ImGui_IsItemActive(ctx)
+    if not preview_mode then
+        local is_active = reaper.ImGui_IsItemActive(ctx)
 
-    if is_active and widget.setValue and not is_disabled then
-        local mouse_x, mouse_y = reaper.ImGui_GetMousePos(ctx)
-        local key_mods = reaper.ImGui_GetKeyMods(ctx)
-        local is_shift_down = (key_mods & reaper.ImGui_Mod_Shift()) ~= 0
-        local is_cmd_down = (key_mods & reaper.ImGui_Mod_Ctrl()) ~= 0
-        
-        if not widget.last_slider_value then
-            widget.last_slider_value = widget.value
-            widget.slider_drag_start_x = mouse_x
-        end
-        
-        local track_width = track_rel_x2 - track_rel_x1
-        local new_normalized
-        
-        if is_shift_down then
-            local fine_scale = widget.fine_scale or 0.1
-            local delta_x = (mouse_x - widget.slider_drag_start_x) * fine_scale
-            new_normalized = ((widget.last_slider_value - (widget.min_value or 0)) / range) + (delta_x / track_width)
+        if is_active and widget.setValue and not is_disabled then
+            local mouse_x, mouse_y = reaper.ImGui_GetMousePos(ctx)
+            local key_mods = reaper.ImGui_GetKeyMods(ctx)
+            local is_shift_down = (key_mods & reaper.ImGui_Mod_Shift()) ~= 0
+            local is_cmd_down = (key_mods & reaper.ImGui_Mod_Ctrl()) ~= 0
+
+            if not widget.last_slider_value then
+                widget.last_slider_value = widget.value
+                widget.slider_drag_start_x = mouse_x
+            end
+
+            local track_width = track_rel_x2 - track_rel_x1
+            local new_normalized
+
+            if is_shift_down then
+                local fine_scale = widget.fine_scale or 0.1
+                local delta_x = (mouse_x - widget.slider_drag_start_x) * fine_scale
+                new_normalized = ((widget.last_slider_value - (widget.min_value or 0)) / range) + (delta_x / track_width)
+            else
+                local screen_track_x1, _ = coords:toScreen(track_rel_x1, 0)
+                new_normalized = (mouse_x - screen_track_x1) / track_width
+            end
+
+            new_normalized = math.max(0, math.min(1, new_normalized))
+            local new_value = (widget.min_value or 0) + new_normalized * range
+
+            if is_cmd_down and widget.snap_increment then
+                new_value = math.floor(new_value / widget.snap_increment + 0.5) * widget.snap_increment
+            end
+
+            if math.abs(new_value - (widget.value or 0)) > 0.0001 then
+                widget.value = new_value
+                pcall(widget.setValue, new_value)
+            end
         else
-            local screen_track_x1, _ = coords:toScreen(track_rel_x1, 0)
-            new_normalized = (mouse_x - screen_track_x1) / track_width
+            if widget.last_slider_value then
+                widget.last_slider_value = nil
+                widget.slider_drag_start_x = nil
+            end
         end
-        
-        new_normalized = math.max(0, math.min(1, new_normalized))
-        local new_value = (widget.min_value or 0) + new_normalized * range
-        
-        if is_cmd_down and widget.snap_increment then
-            new_value = math.floor(new_value / widget.snap_increment + 0.5) * widget.snap_increment
-        end
-        
-        if math.abs(new_value - (widget.value or 0)) > 0.0001 then
-            widget.value = new_value
-            pcall(widget.setValue, new_value)
-        end
-    else
-        if widget.last_slider_value then
-            widget.last_slider_value = nil
-            widget.slider_drag_start_x = nil
-        end
-    end
 
-    if reaper.ImGui_IsItemHovered(ctx) and reaper.ImGui_IsMouseDoubleClicked(ctx, 0) and not is_disabled then
-        if widget.default_value ~= nil then
-            widget.value = widget.default_value
-            pcall(widget.setValue, widget.default_value)
+        if reaper.ImGui_IsItemHovered(ctx) and reaper.ImGui_IsMouseDoubleClicked(ctx, 0) and not is_disabled then
+            if widget.default_value ~= nil then
+                widget.value = widget.default_value
+                pcall(widget.setValue, widget.default_value)
+            end
         end
     end
 end
@@ -264,10 +266,13 @@ local function updateWidgetValue(widget)
     end
 end
 
-function WidgetRenderer:renderWidget(ctx, button, rel_x, rel_y, coords, draw_list, layout, clicked, is_hovered, is_clicked)
+function WidgetRenderer:renderWidget(ctx, button, rel_x, rel_y, coords, draw_list, layout, clicked, is_hovered, is_clicked, opts)
     if not button.widget then
         return false
     end
+
+    opts = opts or {}
+    local preview_mode = opts.preview_mode == true
 
     local widget = button.widget
 
@@ -280,7 +285,7 @@ function WidgetRenderer:renderWidget(ctx, button, rel_x, rel_y, coords, draw_lis
     local render_width = layout and layout.width or widget.width
 
     local sub_hit = nil
-    if widget.hitTestSubcontrols then
+    if not preview_mode and widget.hitTestSubcontrols then
         sub_hit = widget.hitTestSubcontrols(ctx, coords, rel_x, rel_y, render_width, layout)
     end
 
@@ -289,31 +294,30 @@ function WidgetRenderer:renderWidget(ctx, button, rel_x, rel_y, coords, draw_lis
     local mouse_key = C.Interactions:determineMouseKey(is_hovered, is_clicked)
     local _, _, _, text_color = COLOR_UTILS.getButtonColors(button, state_key, mouse_key)
 
-    -- Handle hover callbacks
-    if is_hovered and widget.onHover then
-        pcall(widget.onHover, widget)
-    elseif not is_hovered and widget.is_hovering then
-        -- Reset hover state when not hovering
-        widget.is_hovering = false
-    end
-
-    -- Handle click callbacks: renderer stays subcontrol-agnostic.
-    if clicked then
-        local subcontrol_handled = false
-        if sub_hit and widget.onSubcontrolClick then
-            local ok, handled = pcall(widget.onSubcontrolClick, widget, sub_hit)
-            -- Existing widgets return nil; treat that as handled to preserve behavior.
-            subcontrol_handled = ok and handled ~= false
+    if not preview_mode then
+        -- Handle hover callbacks
+        if is_hovered and widget.onHover then
+            pcall(widget.onHover, widget)
+        elseif not is_hovered and widget.is_hovering then
+            widget.is_hovering = false
         end
 
-        if widget.onClick and (not sub_hit or not subcontrol_handled) then
-            pcall(widget.onClick, widget, sub_hit)
-        end
-    end
+        -- Handle click callbacks: renderer stays subcontrol-agnostic.
+        if clicked then
+            local subcontrol_handled = false
+            if sub_hit and widget.onSubcontrolClick then
+                local ok, handled = pcall(widget.onSubcontrolClick, widget, sub_hit)
+                subcontrol_handled = ok and handled ~= false
+            end
 
-    -- Handle right-click callbacks
-    if reaper.ImGui_IsMouseClicked(ctx, 1) and is_hovered and widget.onRightClick then
-        pcall(widget.onRightClick, widget)
+            if widget.onClick and (not sub_hit or not subcontrol_handled) then
+                pcall(widget.onClick, widget, sub_hit)
+            end
+        end
+
+        if reaper.ImGui_IsMouseClicked(ctx, 1) and is_hovered and widget.onRightClick then
+            pcall(widget.onRightClick, widget)
+        end
     end
 
     if widget.type == "display" then
@@ -321,11 +325,11 @@ function WidgetRenderer:renderWidget(ctx, button, rel_x, rel_y, coords, draw_lis
         return true, render_width
         
     elseif widget.type == "slider" then
-        renderSliderWidget(ctx, widget, rel_x, rel_y, render_width, coords, draw_list, text_color)
+        renderSliderWidget(ctx, widget, rel_x, rel_y, render_width, coords, draw_list, text_color, preview_mode)
         return true, render_width
         
     elseif widget.type == "dropdown" then
-        if clicked then
+        if clicked and not preview_mode then
             refreshWidgetDropdownMenu(widget)
             local temp_button = {
                 -- Use toolbar button id (stable, no spaces); tostring(widget) breaks ImGui ids ("table: 0x...")
@@ -346,6 +350,28 @@ function WidgetRenderer:renderWidget(ctx, button, rel_x, rel_y, coords, draw_lis
     end
 
     return false
+end
+
+-- Non-interactive draw for widget picker previews (same graphics as the toolbar).
+function WidgetRenderer:renderWidgetPreview(ctx, preview_button, rel_x, rel_y, coords, draw_list, layout)
+    local fake_layout = {
+        width = layout.width,
+        height = layout.height or CONFIG.SIZES.HEIGHT,
+        extra_padding = layout.extra_padding or 0
+    }
+    return self:renderWidget(
+        ctx,
+        preview_button,
+        rel_x,
+        rel_y,
+        coords,
+        draw_list,
+        fake_layout,
+        false,
+        false,
+        false,
+        { preview_mode = true }
+    )
 end
 
 return WidgetRenderer.new()

--- a/Systems/Layout_Manager.lua
+++ b/Systems/Layout_Manager.lua
@@ -447,6 +447,7 @@ end
 
 -- Calculate widget button width
 function LayoutManager:calculateWidgetButtonWidth(ctx, button)
+    local layout_cache = CACHE_UTILS.ensureButtonCacheSubtable(button, "layout")
     local extra_padding = self:calculateExtraPadding(button)
     local inner
     if button.widget.getLayoutWidth then
@@ -455,11 +456,15 @@ function LayoutManager:calculateWidgetButtonWidth(ctx, button)
         inner = button.widget.width
     end
 
-    button.cache.layout.width = inner + extra_padding
-    button.cache.layout.extra_padding = extra_padding
-    button.cache.layout.height = CONFIG.SIZES.HEIGHT
+    if inner == nil then
+        inner = CONFIG.SIZES.MIN_WIDTH
+    end
 
-    return button.cache.layout.width, button.cache.layout.extra_padding
+    layout_cache.width = inner + extra_padding
+    layout_cache.extra_padding = extra_padding
+    layout_cache.height = CONFIG.SIZES.HEIGHT
+
+    return layout_cache.width, layout_cache.extra_padding
 end
 
 -- Get icon width from button

--- a/Systems/Widgets_Manager.lua
+++ b/Systems/Widgets_Manager.lua
@@ -43,33 +43,49 @@ function WidgetsManager:scanWidgets()
     end
 end
 
-function WidgetsManager:assignWidgetToButton(button, widget_name)
-    if not button or not WIDGETS[widget_name] then
-        return false
+-- Fresh instance for toolbar or preview (not yet assigned to a button).
+function WidgetsManager:cloneWidgetInstance(widget_name)
+    if not WIDGETS[widget_name] then
+        return nil
     end
-    
+
     local widget = WIDGETS[widget_name]
-    
-    -- Copy ALL properties and functions from the original widget
     local widget_instance = {}
     for key, value in pairs(widget) do
         widget_instance[key] = value
     end
-    
-    -- Override with instance-specific values
+
     widget_instance.name = widget_name
     widget_instance.value = 0
     widget_instance.last_update_time = 0
     widget_instance.update_interval = widget.update_interval or 0.1
-    
-    -- Initialize with current value if getValue exists
+
+    for key in pairs(widget_instance) do
+        if type(key) == "string" and key:match("^__guard_") then
+            widget_instance[key] = nil
+        end
+    end
+
     if widget_instance.getValue then
         local success, value = pcall(widget_instance.getValue, widget_instance)
         if success then
             widget_instance.value = value
         end
     end
-    
+
+    return widget_instance
+end
+
+function WidgetsManager:assignWidgetToButton(button, widget_name)
+    if not button or not WIDGETS[widget_name] then
+        return false
+    end
+
+    local widget_instance = self:cloneWidgetInstance(widget_name)
+    if not widget_instance then
+        return false
+    end
+
     -- Store on button
     button.widget = widget_instance
     


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The **Assign / Change Widget** dialog now shows a **scrollable grid (three columns)**. Each cell is a **bordered preview** that draws the widget the same way it appears on the toolbar, using the **target button’s current colors** (custom colors, user colors, and border offset when linked).

## Interaction

- **Click** a tile to select it (selected tile gets a highlighted border).
- **Double-click** a tile or click **OK** to assign that widget to the button.
- **Cancel** closes without changes.

## Implementation notes

- `WidgetsManager:cloneWidgetInstance` centralizes widget instance creation; guard keys from pcall caching are cleared on clone.
- `WidgetRenderer` supports `preview_mode` so previews do not run clicks, hovers, slider drag, or open dropdown menus; `renderWidgetPreview` wraps that for the picker.
- A single lightweight `ButtonDefinition` shell is reused for previews so color resolution matches real buttons.

## Files

- `Menus/Button_Settings_Menu.lua` — grid UI and preview layout
- `Renderers/_Widgets.lua` — preview rendering path
- `Systems/Widgets_Manager.lua` — `cloneWidgetInstance`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51dc6bac-3e83-4519-a026-f04f6abef17b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51dc6bac-3e83-4519-a026-f04f6abef17b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

